### PR TITLE
Support Waveshare RP2040-Zero board

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sku: [ pico, pico2 ]
+        sku: [ pico, pico2, waveshare_rp2040_zero ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ help:
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  all/build         Build all firmware variants (pico, pico2, waveshare_rp2040_zero) (default)."
+	@echo "  all/build         Build all firmware variants ($(ALL_SKUS)) (default)."
 	@echo "  pico              Build for Raspberry Pi Pico."
 	@echo "  pico2             Build for Raspberry Pi Pico 2."
 	@echo "  waveshare_rp2040_zero Build for Waveshare RP2040-Zero."

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 
 # --- SKUs ---
 # List of all SKUs to build with `make all`
-ALL_SKUS = pico pico2
+ALL_SKUS = pico pico2 waveshare_rp2040_zero
 
 # Name of the build directory
 BUILD_DIR = build
@@ -47,9 +47,10 @@ help:
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  all/build         Build all firmware variants (pico, pico2) (default)."
+	@echo "  all/build         Build all firmware variants (pico, pico2, waveshare_rp2040_zero) (default)."
 	@echo "  pico              Build for Raspberry Pi Pico."
-	@echo "  pico2             Build for Raspberry Pi Pico (same as pico)."
+	@echo "  pico2             Build for Raspberry Pi Pico 2."
+	@echo "  waveshare_rp2040_zero Build for Waveshare RP2040-Zero."
 	@echo "  clean             Remove build artifacts."
 	@echo "  help              Show this help message."
 	@echo ""
@@ -65,7 +66,7 @@ $(ALL_SKUS):
 		exit 1; \
 	fi
 	@echo "--- Building SKU: $@ ---"
-	$(eval BOARD := $(if $(filter pico2,$@),pico2,pico))
+	$(eval BOARD := $@)
 	@echo "--- Configuring build with CMake for board $(BOARD) ---"
 	mkdir -p $(BUILD_DIR)/$@
 	@echo "PICO_SDK_PATH is $(PICO_SDK_PATH)"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 必要なもの
 
-- [Raspberry Pi Pico](https://www.raspberrypi.com/products/raspberry-pi-pico/)又は[Raspberry Pi Pico2](https://www.raspberrypi.com/products/raspberry-pi-pico-2/) 1台
+- [Raspberry Pi Pico](https://www.raspberrypi.com/products/raspberry-pi-pico/)、[Raspberry Pi Pico2](https://www.raspberrypi.com/products/raspberry-pi-pico-2/)又は[Waveshare RP2040-Zero](https://www.waveshare.com/rp2040-zero.htm) 1台
 - USB-Serial変換器 1台
 - USB ケーブル 2本(PCとUSB-Serial変換器、Raspberry Pi PicoとSwitchの接続用)
 - PicoとUSB-Serial変換器を接続用のジャンパ線等
@@ -36,6 +36,7 @@
     このリポジトリの[Releasesページ](https://github.com/yqYo1/PokeControllerForPico/releases)から、お使いのボードに対応する `.uf2` ファイルをダウンロードします。
     -   Pico: `PokeControllerForPico-pico.uf2`
     -   Pico2: `PokeControllerForPico-pico2.uf2`
+    -   Waveshare RP2040-Zero: `PokeControllerForPico-waveshare_rp2040_zero.uf2`
 
 2.  **PicoをBOOTSELモードでPCに接続します。**
     Picoの「BOOTSEL」ボタンを押しながら、PCにUSBケーブルで接続します。
@@ -103,6 +104,9 @@ sudo apt-get update && sudo apt-get install -y git cmake make gcc-arm-none-eabi
 
    # Raspberry Pi Pico 2向けにビルド
    make pico2
+
+   # Waveshare RP2040-Zero向けにビルド
+   make waveshare_rp2040_zero
    ```
    ビルドが成功すると、`build/` ディレクトリ内に `.uf2` ファイル (例: `PokeControllerForPico-pico.uf2`) が生成されます。
 


### PR DESCRIPTION
This change adds support for the Waveshare RP2040-Zero board to the project.
It updates the Makefile to include the new SKU and refactors the board selection logic to be more maintainable.
The CI configuration in `.github/workflows/build.yml` is updated to include the new board in the build matrix, which also ensures it appears in Nightly builds.
Documentation in `README.md` is updated to reflect the new board support.

Fixes #9

---
*PR created automatically by Jules for task [11797868856805529404](https://jules.google.com/task/11797868856805529404) started by @yqYo1*