### PR TITLE
test: add host-side serial parser tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,24 @@ env:
   PICO_SDK_VERSION: '2.2.0'
 
 jobs:
+  Host-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake g++
+
+      - name: Configure tests
+        run: cmake -B build_test -S . -DBUILD_TESTING=ON
+
+      - name: Build tests
+        run: cmake --build build_test
+
+      - name: Run tests
+        run: ctest --test-dir build_test --output-on-failure
+
   Build-firmware:
     runs-on: ubuntu-latest
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,15 @@
 !/docs/
 /docs/*
 !/docs/*.md
+
+!/tests/
+/tests/*
+!/tests/*.cpp
+!/tests/*.h
+!/tests/vectors/
+/tests/vectors/*
+!/tests/vectors/*.json
+
+!/scripts/
+/scripts/*
+!/scripts/*.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,12 @@ Before making any changes to `PokeControllerForPico_Func.cpp` or how UART inputs
 ## 3. Building the Project
 
 For build instructions (CMake, Pico SDK, etc.), please refer directly to the user guide in `README.md`. It explains the standard process of fetching the 2.2.0 `pico-sdk` and running `make pico`.
+
+## 4. Testing Policy (Host-Side Tests)
+
+When adding automated tests for firmware logic, **extract pure, host-testable logic** into platform-independent C++ modules instead of mocking the entire Pico SDK.
+
+- Keep hardware-dependent code (GPIO, UART, timers, etc.) in the firmware-specific source files.
+- Move protocol parsing, state-machine logic, or other algorithms that do not depend on the Pico SDK into separate `.cpp`/`.h` files under `src/`.
+- Use the existing `BUILD_TESTING` CMake option to compile and run these extracted modules on the host (x86_64/Linux) with a standard test framework such as Catch2.
+- This approach ensures the **same source file** is compiled for both the ARM firmware target and the host test runner, avoiding drift between test and production code.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.13)
 
-# Pull in Pico SDK from git submodule
-include(pico_sdk_import.cmake)
+option(BUILD_TESTING "Build host tests" OFF)
+
+if(NOT BUILD_TESTING)
+    # Pull in Pico SDK from git submodule
+    include(pico_sdk_import.cmake)
+endif()
 
 project(PokeControllerForPico C CXX ASM)
 
@@ -11,36 +15,63 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
-# Initializes the Pico SDK
-pico_sdk_init()
+if(NOT BUILD_TESTING)
+    # Initializes the Pico SDK
+    pico_sdk_init()
 
-# Add the source files to the executable
-add_executable(PokeControllerForPico
-    src/main.cpp
-    src/PokeControllerForPico_Func.cpp
-    src/CustomKeyboard.cpp
-    src/usb_descriptors.c
-)
+    # Add the source files to the executable
+    add_executable(PokeControllerForPico
+        src/main.cpp
+        src/PokeControllerForPico_Func.cpp
+        src/CustomKeyboard.cpp
+        src/usb_descriptors.c
+        src/serial_parser.cpp
+    )
 
-# Add the directory with our headers to the include path
-target_include_directories(PokeControllerForPico PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/src
-)
+    # Add the directory with our headers to the include path
+    target_include_directories(PokeControllerForPico PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}/src
+    )
 
-# Link to Pico libraries
-target_link_libraries(PokeControllerForPico
-    pico_stdlib
-    hardware_uart
-)
+    # Link to Pico libraries
+    target_link_libraries(PokeControllerForPico
+        pico_stdlib
+        hardware_uart
+    )
 
-# Link to TinyUSB
-# The "tinyusb_device" target is created by the Pico SDK
-# It requires a tusb_config.h file. We point it to ours.
-target_link_libraries(PokeControllerForPico tinyusb_device)
-target_compile_definitions(PokeControllerForPico INTERFACE
-    TUSB_CONFIG_FILE='${CMAKE_CURRENT_LIST_DIR}/src/tusb_config.h'
-)
+    # Link to TinyUSB
+    target_link_libraries(PokeControllerForPico tinyusb_device)
+    target_compile_definitions(PokeControllerForPico INTERFACE
+        TUSB_CONFIG_FILE='${CMAKE_CURRENT_LIST_DIR}/src/tusb_config.h'
+    )
 
+    # Create .uf2 file
+    pico_add_extra_outputs(PokeControllerForPico)
+endif()
 
-# Create .uf2 file
-pico_add_extra_outputs(PokeControllerForPico)
+if(BUILD_TESTING)
+    enable_testing()
+    
+    include(FetchContent)
+    FetchContent_Declare(
+        Catch2
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_TAG        v3.8.0
+    )
+    FetchContent_Declare(
+        json
+        GIT_REPOSITORY https://github.com/nlohmann/json.git
+        GIT_TAG        v3.11.3
+    )
+    FetchContent_MakeAvailable(Catch2 json)
+    
+    add_executable(pico_parser_tests
+        tests/test_parser.cpp
+        src/serial_parser.cpp
+    )
+    target_include_directories(pico_parser_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    target_link_libraries(pico_parser_tests PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
+    
+    include(Catch)
+    catch_discover_tests(pico_parser_tests)
+endif()

--- a/src/PokeControllerForPico_Func.cpp
+++ b/src/PokeControllerForPico_Func.cpp
@@ -1,4 +1,5 @@
 #include "PokeControllerForPico_Func.h"
+#include "serial_parser.h"
 #include "pico/stdlib.h"
 #include "pico/time.h"
 #include <stdio.h>
@@ -77,12 +78,13 @@ const char* cmd_name[MAX_BUFFER] = {
 
 static int step_size_buf;
 
-uint8_t pc_lx, pc_ly, pc_rx, pc_ry;
 uint32_t KeyValue;
 uint32_t YearChangeCnt;//0~4294967295までの整数
 uint32_t MonthChangeCnt;//0~4294967295までの整数
 uint32_t DayChangeCnt;//0~4294967295までの整数
 int NowYear = 0;
+
+static pokecon::GamepadState g_gamepad_state;
 
 static unsigned long s_ultime;
 static bool blduration = false;
@@ -124,6 +126,7 @@ void Keyboard_Init(void)
 /* 送信するデータをリセットする */
 void ResetDirections(void)
 {
+  pokecon::ResetGamepadState(g_gamepad_state);
   pc_report.LX = 128;
   pc_report.LY = 128;
   pc_report.RX = 128;
@@ -134,8 +137,6 @@ void ResetDirections(void)
 void ParseLine(char* line)
 {
   char cmd[16];
-  uint16_t p_btns;
-  uint8_t p_hat;
   // get command
   int ret = sscanf(line, "%s", cmd);
   if (ret == EOF) {
@@ -144,113 +145,17 @@ void ParseLine(char* line)
     proc_state = NONE;
     ResetDirections();
   } else if (cmd[0] >= '0' && cmd[0] <= '9') {
-    uint8_t char_pos = 0;
-
-    p_btns = 0;
-    while (line[char_pos] != ' ' && line[char_pos] != '\r') {
-      p_btns *= 16;
-      if (line[char_pos] >= '0' && line[char_pos] <= '9') {
-        p_btns += (line[char_pos] - '0');
-      } else if (line[char_pos] >= 'A' && line[char_pos] <= 'F') {
-        p_btns += (line[char_pos] - 'A' + 10);
-      } else {
-        p_btns += (line[char_pos] - 'a' + 10);
-      }
-      char_pos++;
+    if (pokecon::ParseSerialLine(line, g_gamepad_state)) {
+      pc_report.Hat = g_gamepad_state.hat;
+      pc_report.Button = g_gamepad_state.buttons;
+      pc_report.LX = g_gamepad_state.lx;
+      pc_report.LY = g_gamepad_state.ly;
+      pc_report.RX = g_gamepad_state.rx;
+      pc_report.RY = g_gamepad_state.ry;
+      proc_state = PC_CALL;
+    } else {
+      proc_state = DEBUG2;
     }
-    if (line[char_pos] != '\r') char_pos++;
-
-    p_hat = 0;
-    while (line[char_pos] != ' ' && line[char_pos] != '\r') {
-      p_hat *= 16;
-      if (line[char_pos] >= '0' && line[char_pos] <= '9') {
-        p_hat += (line[char_pos] - '0');
-      } else if (line[char_pos] >= 'A' && line[char_pos] <= 'F') {
-        p_hat += (line[char_pos] - 'A' + 10);
-      } else {
-        p_hat += (line[char_pos] - 'a' + 10);
-      }
-      char_pos++;
-    }
-    if (line[char_pos] != '\r') char_pos++;
-
-    while (line[char_pos] != ' ' && line[char_pos] != '\r') {
-      pc_lx *= 16;
-      if (line[char_pos] >= '0' && line[char_pos] <= '9') {
-        pc_lx += (line[char_pos] - '0');
-      } else if (line[char_pos] >= 'A' && line[char_pos] <= 'F') {
-        pc_lx += (line[char_pos] - 'A' + 10);
-      } else {
-        pc_lx += (line[char_pos] - 'a' + 10);
-      }
-      char_pos++;
-    }
-    if (line[char_pos] != '\r') char_pos++;
-
-    while (line[char_pos] != ' ' && line[char_pos] != '\r') {
-      pc_ly *= 16;
-      if (line[char_pos] >= '0' && line[char_pos] <= '9') {
-        pc_ly += (line[char_pos] - '0');
-      } else if (line[char_pos] >= 'A' && line[char_pos] <= 'F') {
-        pc_ly += (line[char_pos] - 'A' + 10);
-      } else {
-        pc_ly += (line[char_pos] - 'a' + 10);
-      }
-      char_pos++;
-    }
-    if (line[char_pos] != '\r') char_pos++;
-
-    while (line[char_pos] != ' ' && line[char_pos] != '\r') {
-      pc_rx *= 16;
-      if (line[char_pos] >= '0' && line[char_pos] <= '9') {
-        pc_rx += (line[char_pos] - '0');
-      } else if (line[char_pos] >= 'A' && line[char_pos] <= 'F') {
-        pc_rx += (line[char_pos] - 'A' + 10);
-      } else {
-        pc_rx += (line[char_pos] - 'a' + 10);
-      }
-      char_pos++;
-    }
-    if (line[char_pos] != '\r') char_pos++;
-
-    while (line[char_pos] != ' ' && line[char_pos] != '\r') {
-      pc_ry *= 16;
-      if (line[char_pos] >= '0' && line[char_pos] <= '9') {
-        pc_ry += (line[char_pos] - '0');
-      } else if (line[char_pos] >= 'A' && line[char_pos] <= 'F') {
-        pc_ry += (line[char_pos] - 'A' + 10);
-      } else {
-        pc_ry += (line[char_pos] - 'a' + 10);
-      }
-      char_pos++;
-    }
-
-    // HAT : 0(TOP) to 7(TOP_LEFT) in clockwise | 8(CENTER)
-    pc_report.Hat = p_hat;
-
-    // we use bit array for buttons(2 Bytes), which last 2 bits are flags of directions
-    bool use_right = p_btns & 0x0001;
-    bool use_left  = p_btns & 0x0002;
-
-    // Left stick
-    if (use_left) {
-      pc_report.LX = pc_lx;
-      pc_report.LY = pc_ly;
-    }
-
-    // Right stick
-    if (use_right & use_left) {
-      pc_report.RX = pc_rx;
-      pc_report.RY = pc_ry;
-    } else if (use_right) {
-      pc_report.RX = pc_lx;
-      pc_report.RY = pc_ly;
-    }
-
-    p_btns >>= 2;
-    pc_report.Button = p_btns;
-
-    proc_state = PC_CALL;
   } else if (strncmp(line, "\"", 1) == 0) {
     for (int i = 0; i < MAX_BUFFER; i++)
     {

--- a/src/serial_parser.cpp
+++ b/src/serial_parser.cpp
@@ -1,0 +1,145 @@
+#include "serial_parser.h"
+#include <cstring>
+
+namespace pokecon {
+
+void ResetGamepadState(GamepadState& state) {
+    state.buttons = 0;
+    state.hat = 8;   // HAT_CENTER
+    state.lx = 128;  // STICK_CENTER
+    state.ly = 128;
+    state.rx = 128;
+    state.ry = 128;
+}
+
+// Skip leading whitespace (spaces and tabs)
+static void skipWhitespace(const char* line, size_t& pos) {
+    while (line[pos] == ' ' || line[pos] == '\t') pos++;
+}
+
+// Parse a single hex byte token. pos is updated to the next token.
+// Handles optional "0x"/"0X" prefix, multiple spaces, and invalid characters.
+static uint8_t parseHexByte(const char* line, size_t& pos) {
+    skipWhitespace(line, pos);
+
+    // Skip optional 0x / 0X prefix
+    if (line[pos] == '0' && (line[pos + 1] == 'x' || line[pos + 1] == 'X')) {
+        pos += 2;
+    }
+
+    uint8_t value = 0;
+    while (line[pos] != '\0' && line[pos] != ' ' && line[pos] != '\t' && line[pos] != '\r' && line[pos] != '\n') {
+        uint8_t digit;
+        if (line[pos] >= '0' && line[pos] <= '9') {
+            digit = static_cast<uint8_t>(line[pos] - '0');
+        } else if (line[pos] >= 'A' && line[pos] <= 'F') {
+            digit = static_cast<uint8_t>(line[pos] - 'A' + 10);
+        } else if (line[pos] >= 'a' && line[pos] <= 'f') {
+            digit = static_cast<uint8_t>(line[pos] - 'a' + 10);
+        } else {
+            // Invalid character — stop parsing this token
+            break;
+        }
+        value = static_cast<uint8_t>((value * 16) + digit);
+        pos++;
+    }
+
+    skipWhitespace(line, pos);
+    return value;
+}
+
+// Parse a multi-digit hex word token (for buttons).
+static uint16_t parseHexWord(const char* line, size_t& pos) {
+    skipWhitespace(line, pos);
+
+    // Skip optional 0x / 0X prefix
+    if (line[pos] == '0' && (line[pos + 1] == 'x' || line[pos + 1] == 'X')) {
+        pos += 2;
+    }
+
+    uint16_t value = 0;
+    while (line[pos] != '\0' && line[pos] != ' ' && line[pos] != '\t' && line[pos] != '\r' && line[pos] != '\n') {
+        uint16_t digit;
+        if (line[pos] >= '0' && line[pos] <= '9') {
+            digit = static_cast<uint16_t>(line[pos] - '0');
+        } else if (line[pos] >= 'A' && line[pos] <= 'F') {
+            digit = static_cast<uint16_t>(line[pos] - 'A' + 10);
+        } else if (line[pos] >= 'a' && line[pos] <= 'f') {
+            digit = static_cast<uint16_t>(line[pos] - 'a' + 10);
+        } else {
+            // Invalid character — stop parsing this token
+            break;
+        }
+        value = static_cast<uint16_t>((value * 16) + digit);
+        pos++;
+    }
+
+    skipWhitespace(line, pos);
+    return value;
+}
+
+bool ParseSerialLine(const char* line, GamepadState& state) {
+    if (line == nullptr || line[0] == '\0') return false;
+
+    size_t pos = 0;
+    skipWhitespace(line, pos);
+
+    // After skipping whitespace, the line must not be empty and must start
+    // with a digit (handles "0x..." format which is the protocol standard).
+    if (line[pos] == '\0' || !(line[pos] >= '0' && line[pos] <= '9')) return false;
+
+    // Buttons + stick flags
+    uint16_t p_btns = parseHexWord(line, pos);
+
+    // Hat
+    uint8_t p_hat = parseHexByte(line, pos);
+
+    // Read stick values if present in the string
+    uint8_t val1 = state.lx, val2 = state.ly, val3 = state.rx, val4 = state.ry;
+
+    if (line[pos] != '\r' && line[pos] != '\n' && line[pos] != '\0') {
+        val1 = parseHexByte(line, pos);
+    }
+    if (line[pos] != '\r' && line[pos] != '\n' && line[pos] != '\0') {
+        val2 = parseHexByte(line, pos);
+    }
+    if (line[pos] != '\r' && line[pos] != '\n' && line[pos] != '\0') {
+        val3 = parseHexByte(line, pos);
+    }
+    if (line[pos] != '\r' && line[pos] != '\n' && line[pos] != '\0') {
+        val4 = parseHexByte(line, pos);
+    }
+
+    // Stick flags
+    bool use_right = (p_btns & 0x0001) != 0;
+    bool use_left  = (p_btns & 0x0002) != 0;
+
+    // Hat update
+    state.hat = p_hat;
+
+    // Left stick update
+    if (use_left) {
+        state.lx = val1;
+        state.ly = val2;
+    }
+
+    // Right stick update
+    // Note: original code used bitwise AND (use_right & use_left), but
+    // logical AND is the intended behavior.
+    if (use_right && use_left) {
+        state.rx = val3;
+        state.ry = val4;
+    } else if (use_right) {
+        // Original code assigned pc_lx/pc_ly here. Protocol-wise this means
+        // "right stick only" uses the 3rd/4th token values (val1, val2).
+        state.rx = val1;
+        state.ry = val2;
+    }
+
+    // Buttons are shifted by 2 bits
+    state.buttons = p_btns >> 2;
+
+    return true;
+}
+
+} // namespace pokecon

--- a/src/serial_parser.h
+++ b/src/serial_parser.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <cstdint>
+
+namespace pokecon {
+
+struct GamepadState {
+    uint16_t buttons;  // 2ビットシフト後のボタン値
+    uint8_t  hat;
+    uint8_t  lx, ly;   // 左スティック
+    uint8_t  rx, ry;   // 右スティック
+};
+
+// 状態を初期化（デフォルト位置）
+void ResetGamepadState(GamepadState& state);
+
+// シリアル文字列をパースして GamepadState を更新
+// line: 入力文字列（例: "0x0012 8 FF 80" または "0x0001 2 80 FF" 等）
+// state: 前回の状態。スティックフラグなし時にスティック値が維持される
+// 戻り値: パース成功時 true
+bool ParseSerialLine(const char* line, GamepadState& state);
+
+} // namespace pokecon

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1,0 +1,686 @@
+#include <catch2/catch_test_macros.hpp>
+#include <nlohmann/json.hpp>
+#include <fstream>
+#include <filesystem>
+#include "serial_parser.h"
+
+using json = nlohmann::json;
+using namespace pokecon;
+
+TEST_CASE("ResetGamepadState initializes to default values", "[parser]") {
+    GamepadState state;
+    state.buttons = 0xFF;
+    state.hat = 0;
+    state.lx = 0;
+    state.ly = 0;
+    state.rx = 0;
+    state.ry = 0;
+
+    ResetGamepadState(state);
+
+    REQUIRE(state.buttons == 0);
+    REQUIRE(state.hat == 8);    // HAT_CENTER
+    REQUIRE(state.lx == 128);   // STICK_CENTER
+    REQUIRE(state.ly == 128);
+    REQUIRE(state.rx == 128);
+    REQUIRE(state.ry == 128);
+}
+
+TEST_CASE("Parse button-only command", "[parser]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // Aボタン（0x0010）のみ、スティックなし
+    // Extension側では 0x0010 >> 2 = 0x0004 となるが、
+    // パーサーはシフト後の値を返す
+    REQUIRE(ParseSerialLine("0x0010 8", state) == true);
+    REQUIRE(state.buttons == 0x0004);  // 0x0010 >> 2
+    REQUIRE(state.hat == 8);
+    REQUIRE(state.lx == 128);  // スティックフラグなしなので維持
+    REQUIRE(state.ly == 128);
+    REQUIRE(state.rx == 128);
+    REQUIRE(state.ry == 128);
+}
+
+TEST_CASE("Parse button with left stick", "[parser]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // Aボタン（0x0010）+ 左スティックフラグ（0x0002）= 0x0012
+    // 左スティック X=255, Y=128
+    REQUIRE(ParseSerialLine("0x0012 8 FF 80", state) == true);
+    REQUIRE(state.buttons == 0x0004);  // 0x0012 >> 2 = 0x0004
+    REQUIRE(state.hat == 8);
+    REQUIRE(state.lx == 255);
+    REQUIRE(state.ly == 128);
+    REQUIRE(state.rx == 128);  // 右スティックフラグなし
+    REQUIRE(state.ry == 128);
+}
+
+TEST_CASE("Parse button with right stick", "[parser]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // 右スティックフラグ（0x0001）+ 十字キー右（2）
+    // 右スティック X=128, Y=255
+    REQUIRE(ParseSerialLine("0x0001 2 80 FF", state) == true);
+    REQUIRE(state.buttons == 0x0000);  // 0x0001 >> 2 = 0x0000
+    REQUIRE(state.hat == 2);
+    REQUIRE(state.lx == 128);  // 左スティックフラグなしなので維持
+    REQUIRE(state.ly == 128);
+    REQUIRE(state.rx == 128);
+    REQUIRE(state.ry == 255);
+}
+
+TEST_CASE("Parse full command with both sticks", "[parser]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // A+Bボタン（0x0018）+ 両スティックフラグ（0x0003）= 0x001B
+    REQUIRE(ParseSerialLine("0x001B 8 00 00 FF FF", state) == true);
+    REQUIRE(state.buttons == 0x0006);  // 0x001B >> 2 = 0x0006
+    REQUIRE(state.hat == 8);
+    REQUIRE(state.lx == 0x00);
+    REQUIRE(state.ly == 0x00);
+    REQUIRE(state.rx == 0xFF);
+    REQUIRE(state.ry == 0xFF);
+}
+
+TEST_CASE("Stick values persist when flags are not set", "[parser][stateful]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // 最初に左スティックを設定
+    REQUIRE(ParseSerialLine("0x0002 8 FF 80", state) == true);
+    REQUIRE(state.lx == 255);
+    REQUIRE(state.ly == 128);
+
+    // スティックフラグなしでボタンのみ更新
+    REQUIRE(ParseSerialLine("0x0010 8", state) == true);
+    REQUIRE(state.lx == 255);  // 左スティックは維持
+    REQUIRE(state.ly == 128);
+}
+
+TEST_CASE("Right stick overwrites previous value", "[parser][stateful]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // 右スティックを設定
+    REQUIRE(ParseSerialLine("0x0001 8 80 FF", state) == true);
+    REQUIRE(state.rx == 128);
+    REQUIRE(state.ry == 255);
+
+    // 右スティックを別の値で上書き
+    REQUIRE(ParseSerialLine("0x0001 8 FF 00", state) == true);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 0);
+}
+
+TEST_CASE("Boundary values are parsed correctly", "[parser]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // 境界値 0, 128, 255
+    REQUIRE(ParseSerialLine("0x0003 8 00 80 FF 00", state) == true);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 128);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 0);
+}
+
+TEST_CASE("Multiple buttons are ORed correctly", "[parser]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // A(0x0010) + B(0x0008) = 0x0018、スティックなし
+    // パーサーはシフト後の値を返す: 0x0018 >> 2 = 0x0006
+    REQUIRE(ParseSerialLine("0x0018 8", state) == true);
+    REQUIRE(state.buttons == 0x0006);
+}
+
+TEST_CASE("Empty string returns false", "[parser][error]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    REQUIRE(ParseSerialLine("", state) == false);
+}
+
+TEST_CASE("Non-numeric start returns false", "[parser][error]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    REQUIRE(ParseSerialLine("hello world", state) == false);
+}
+
+TEST_CASE("Leading whitespace is skipped", "[parser][robustness]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    REQUIRE(ParseSerialLine("  0x0010 8", state) == true);
+    REQUIRE(state.buttons == 0x0004);
+    REQUIRE(state.hat == 8);
+}
+
+TEST_CASE("Leading tab is skipped", "[parser][robustness]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    REQUIRE(ParseSerialLine("\t0x0010 8", state) == true);
+    REQUIRE(state.buttons == 0x0004);
+    REQUIRE(state.hat == 8);
+}
+
+TEST_CASE("Multiple spaces between tokens", "[parser][robustness]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    REQUIRE(ParseSerialLine("0x0012   8   FF   80", state) == true);
+    REQUIRE(state.buttons == 0x0004);
+    REQUIRE(state.hat == 8);
+    REQUIRE(state.lx == 255);
+    REQUIRE(state.ly == 128);
+}
+
+TEST_CASE("Mixed tabs and spaces between tokens", "[parser][robustness]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    REQUIRE(ParseSerialLine("0x0003\t8\t00\t80\tFF\t00", state) == true);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 128);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 0);
+}
+
+TEST_CASE("Invalid hex characters stop parsing for that token", "[parser][robustness]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // "0x1G" should parse as 0x1 (stops at 'G'), then hat = 0
+    REQUIRE(ParseSerialLine("0x1G 0", state) == true);
+    REQUIRE(state.buttons == 0);  // 0x1 >> 2 = 0
+    REQUIRE(state.hat == 0);
+}
+
+TEST_CASE("Empty line with only whitespace returns false", "[parser][error]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    REQUIRE(ParseSerialLine("   ", state) == false);
+    REQUIRE(ParseSerialLine("\t\t", state) == false);
+}
+
+// ============================================================================
+// Exhaustive button combination tests (all 2^14 = 16384 patterns)
+// ============================================================================
+
+TEST_CASE("Exhaustive button combinations (all 2^14 patterns)", "[parser][buttons][exhaustive]") {
+    for (uint16_t buttons = 0; buttons < 16384; ++buttons) {
+        GamepadState state;
+        ResetGamepadState(state);
+
+        // スティックフラグなしで全ボタン組み合わせをテスト
+        // input = buttons << 2 (最下位2ビットはスティックフラグ)
+        uint16_t input_val = buttons << 2;
+        char line[32];
+        snprintf(line, sizeof(line), "0x%04X 8", input_val);
+
+        CAPTURE(line);
+        REQUIRE(ParseSerialLine(line, state) == true);
+        REQUIRE(state.buttons == buttons);
+        REQUIRE(state.hat == 8);
+        REQUIRE(state.lx == 128);
+        REQUIRE(state.ly == 128);
+        REQUIRE(state.rx == 128);
+        REQUIRE(state.ry == 128);
+    }
+}
+
+TEST_CASE("Exhaustive button combinations with left stick flag", "[parser][buttons][exhaustive]") {
+    for (uint16_t buttons = 0; buttons < 16384; ++buttons) {
+        GamepadState state;
+        ResetGamepadState(state);
+
+        // 左スティックフラグ(0x0002)付き
+        uint16_t input_val = (buttons << 2) | 0x0002;
+        char line[64];
+        snprintf(line, sizeof(line), "0x%04X 8 80 80", input_val);
+
+        CAPTURE(line);
+        REQUIRE(ParseSerialLine(line, state) == true);
+        REQUIRE(state.buttons == buttons);
+        REQUIRE(state.hat == 8);
+        REQUIRE(state.lx == 128);
+        REQUIRE(state.ly == 128);
+        REQUIRE(state.rx == 128);
+        REQUIRE(state.ry == 128);
+    }
+}
+
+TEST_CASE("Exhaustive button combinations with right stick flag", "[parser][buttons][exhaustive]") {
+    for (uint16_t buttons = 0; buttons < 16384; ++buttons) {
+        GamepadState state;
+        ResetGamepadState(state);
+
+        // 右スティックフラグ(0x0001)付き
+        uint16_t input_val = (buttons << 2) | 0x0001;
+        char line[64];
+        snprintf(line, sizeof(line), "0x%04X 8 80 80", input_val);
+
+        CAPTURE(line);
+        REQUIRE(ParseSerialLine(line, state) == true);
+        REQUIRE(state.buttons == buttons);
+        REQUIRE(state.hat == 8);
+        REQUIRE(state.lx == 128);
+        REQUIRE(state.ly == 128);
+        REQUIRE(state.rx == 128);
+        REQUIRE(state.ry == 128);
+    }
+}
+
+TEST_CASE("Exhaustive button combinations with both stick flags", "[parser][buttons][exhaustive]") {
+    for (uint16_t buttons = 0; buttons < 16384; ++buttons) {
+        GamepadState state;
+        ResetGamepadState(state);
+
+        // 両スティックフラグ(0x0003)付き
+        uint16_t input_val = (buttons << 2) | 0x0003;
+        char line[64];
+        snprintf(line, sizeof(line), "0x%04X 8 80 80 80 80", input_val);
+
+        CAPTURE(line);
+        REQUIRE(ParseSerialLine(line, state) == true);
+        REQUIRE(state.buttons == buttons);
+        REQUIRE(state.hat == 8);
+        REQUIRE(state.lx == 128);
+        REQUIRE(state.ly == 128);
+        REQUIRE(state.rx == 128);
+        REQUIRE(state.ry == 128);
+    }
+}
+
+// ============================================================================
+// Stick state transition tests (stateful behavior across sequential commands)
+// ============================================================================
+
+TEST_CASE("Left stick persists through button-only commands", "[parser][stateful][transition]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // Step 1: Set left stick to (0, 0)
+    REQUIRE(ParseSerialLine("0x0002 8 00 00", state) == true);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 0);
+    REQUIRE(state.rx == 128);
+    REQUIRE(state.ry == 128);
+
+    // Step 2: Button-only command — left stick must persist
+    REQUIRE(ParseSerialLine("0x0004 8", state) == true);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 0);
+    REQUIRE(state.rx == 128);
+    REQUIRE(state.ry == 128);
+
+    // Step 3: Another button-only command — left stick still persists
+    REQUIRE(ParseSerialLine("0x0010 8", state) == true);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 0);
+}
+
+TEST_CASE("Right stick persists through button-only commands", "[parser][stateful][transition]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // Step 1: Set right stick to (255, 255)
+    REQUIRE(ParseSerialLine("0x0001 8 FF FF", state) == true);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 255);
+
+    // Step 2: Button-only command — right stick must persist
+    REQUIRE(ParseSerialLine("0x0004 8", state) == true);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 255);
+
+    // Step 3: Another button-only command — right stick still persists
+    REQUIRE(ParseSerialLine("0x0010 8", state) == true);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 255);
+}
+
+TEST_CASE("Left and right sticks are independent", "[parser][stateful][transition]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // Step 1: Set left stick only
+    REQUIRE(ParseSerialLine("0x0002 8 00 FF", state) == true);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 255);
+    REQUIRE(state.rx == 128);
+    REQUIRE(state.ry == 128);
+
+    // Step 2: Set right stick only — left stick must not change
+    REQUIRE(ParseSerialLine("0x0001 8 FF 00", state) == true);
+    REQUIRE(state.lx == 0);   // preserved
+    REQUIRE(state.ly == 255); // preserved
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 0);
+
+    // Step 3: Update left stick again — right stick must not change
+    REQUIRE(ParseSerialLine("0x0002 8 80 80", state) == true);
+    REQUIRE(state.lx == 128);
+    REQUIRE(state.ly == 128);
+    REQUIRE(state.rx == 255); // preserved
+    REQUIRE(state.ry == 0);   // preserved
+}
+
+TEST_CASE("Stick values transition through multiple changes", "[parser][stateful][transition]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // Left stick: 128(center) → 0(min) → 255(max) → 128(center)
+    REQUIRE(ParseSerialLine("0x0002 8 80 80", state) == true);
+    REQUIRE(state.lx == 128);
+    REQUIRE(state.ly == 128);
+
+    REQUIRE(ParseSerialLine("0x0002 8 00 00", state) == true);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 0);
+
+    REQUIRE(ParseSerialLine("0x0002 8 FF FF", state) == true);
+    REQUIRE(state.lx == 255);
+    REQUIRE(state.ly == 255);
+
+    REQUIRE(ParseSerialLine("0x0002 8 80 80", state) == true);
+    REQUIRE(state.lx == 128);
+    REQUIRE(state.ly == 128);
+
+    // Right stick: 128(center) → 255(max) → 0(min) → 128(center)
+    REQUIRE(ParseSerialLine("0x0001 8 FF FF", state) == true);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 255);
+
+    REQUIRE(ParseSerialLine("0x0001 8 00 00", state) == true);
+    REQUIRE(state.rx == 0);
+    REQUIRE(state.ry == 0);
+
+    REQUIRE(ParseSerialLine("0x0001 8 80 80", state) == true);
+    REQUIRE(state.rx == 128);
+    REQUIRE(state.ry == 128);
+}
+
+TEST_CASE("Both sticks then one stick preserves the other", "[parser][stateful][transition]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // Step 1: Set both sticks
+    REQUIRE(ParseSerialLine("0x0003 8 00 FF FF 00", state) == true);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 255);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 0);
+
+    // Step 2: Update left stick only — right stick must persist
+    REQUIRE(ParseSerialLine("0x0002 8 80 80", state) == true);
+    REQUIRE(state.lx == 128);
+    REQUIRE(state.ly == 128);
+    REQUIRE(state.rx == 255); // preserved
+    REQUIRE(state.ry == 0);   // preserved
+
+    // Step 3: Update right stick only — left stick must persist
+    REQUIRE(ParseSerialLine("0x0001 8 00 00", state) == true);
+    REQUIRE(state.lx == 128); // preserved
+    REQUIRE(state.ly == 128); // preserved
+    REQUIRE(state.rx == 0);
+    REQUIRE(state.ry == 0);
+}
+
+TEST_CASE("Complex transition: buttons and sticks mixed", "[parser][stateful][transition]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // Sequence: left stick → buttons → right stick → buttons → both sticks
+    REQUIRE(ParseSerialLine("0x0002 8 00 80", state) == true);
+    REQUIRE(state.buttons == 0);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 128);
+
+    REQUIRE(ParseSerialLine("0x0004 8", state) == true);
+    REQUIRE(state.buttons == 1); // Y button
+    REQUIRE(state.lx == 0);      // preserved
+    REQUIRE(state.ly == 128);    // preserved
+
+    REQUIRE(ParseSerialLine("0x0001 8 FF 00", state) == true);
+    REQUIRE(state.buttons == 0); // cleared
+    REQUIRE(state.lx == 0);      // preserved
+    REQUIRE(state.ly == 128);    // preserved
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 0);
+
+    REQUIRE(ParseSerialLine("0x0010 8", state) == true);
+    REQUIRE(state.buttons == 4); // A button
+    REQUIRE(state.rx == 255);    // preserved
+    REQUIRE(state.ry == 0);      // preserved
+
+    REQUIRE(ParseSerialLine("0x0003 8 80 80 80 80", state) == true);
+    REQUIRE(state.buttons == 0);
+    REQUIRE(state.lx == 128);
+    REQUIRE(state.ly == 128);
+    REQUIRE(state.rx == 128);
+    REQUIRE(state.ry == 128);
+}
+
+TEST_CASE("Buttons change but sticks persist across mixed commands", "[parser][stateful][transition]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // Initialize with both sticks set
+    REQUIRE(ParseSerialLine("0x0003 8 00 00 FF FF", state) == true);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 0);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 255);
+
+    // Rapidly change buttons without touching sticks
+    REQUIRE(ParseSerialLine("0x0004 8", state) == true);
+    REQUIRE(state.buttons == 1);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 0);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 255);
+
+    REQUIRE(ParseSerialLine("0x0008 8", state) == true);
+    REQUIRE(state.buttons == 2);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 0);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 255);
+
+    REQUIRE(ParseSerialLine("0x0010 8", state) == true);
+    REQUIRE(state.buttons == 4);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 0);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 255);
+
+    REQUIRE(ParseSerialLine("0x0018 8", state) == true);
+    REQUIRE(state.buttons == 6);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 0);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 255);
+}
+
+TEST_CASE("Boundary value transitions for sticks", "[parser][stateful][transition]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    // 0 → 255 → 128 on left stick
+    REQUIRE(ParseSerialLine("0x0002 8 00 00", state) == true);
+    REQUIRE(state.lx == 0);
+    REQUIRE(state.ly == 0);
+
+    REQUIRE(ParseSerialLine("0x0002 8 FF FF", state) == true);
+    REQUIRE(state.lx == 255);
+    REQUIRE(state.ly == 255);
+
+    REQUIRE(ParseSerialLine("0x0002 8 80 80", state) == true);
+    REQUIRE(state.lx == 128);
+    REQUIRE(state.ly == 128);
+
+    // 255 → 0 → 128 on right stick
+    REQUIRE(ParseSerialLine("0x0001 8 FF FF", state) == true);
+    REQUIRE(state.rx == 255);
+    REQUIRE(state.ry == 255);
+
+    REQUIRE(ParseSerialLine("0x0001 8 00 00", state) == true);
+    REQUIRE(state.rx == 0);
+    REQUIRE(state.ry == 0);
+
+    REQUIRE(ParseSerialLine("0x0001 8 80 80", state) == true);
+    REQUIRE(state.rx == 128);
+    REQUIRE(state.ry == 128);
+}
+
+TEST_CASE("Left stick X transitions through all values 0..255", "[parser][stateful][transition][exhaustive]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    for (int x = 0; x <= 255; ++x) {
+        char line[32];
+        snprintf(line, sizeof(line), "0x0002 8 %02X 80", x);
+        CAPTURE(line);
+        REQUIRE(ParseSerialLine(line, state) == true);
+        REQUIRE(state.lx == x);
+        REQUIRE(state.ly == 128);  // unchanged
+    }
+}
+
+TEST_CASE("Left stick Y transitions through all values 0..255", "[parser][stateful][transition][exhaustive]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    for (int y = 0; y <= 255; ++y) {
+        char line[32];
+        snprintf(line, sizeof(line), "0x0002 8 80 %02X", y);
+        CAPTURE(line);
+        REQUIRE(ParseSerialLine(line, state) == true);
+        REQUIRE(state.lx == 128);  // unchanged
+        REQUIRE(state.ly == y);
+    }
+}
+
+TEST_CASE("Right stick X transitions through all values 0..255", "[parser][stateful][transition][exhaustive]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    for (int x = 0; x <= 255; ++x) {
+        char line[32];
+        snprintf(line, sizeof(line), "0x0001 8 %02X 80", x);
+        CAPTURE(line);
+        REQUIRE(ParseSerialLine(line, state) == true);
+        REQUIRE(state.rx == x);
+        REQUIRE(state.ry == 128);  // unchanged
+    }
+}
+
+TEST_CASE("Right stick Y transitions through all values 0..255", "[parser][stateful][transition][exhaustive]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    for (int y = 0; y <= 255; ++y) {
+        char line[32];
+        snprintf(line, sizeof(line), "0x0001 8 80 %02X", y);
+        CAPTURE(line);
+        REQUIRE(ParseSerialLine(line, state) == true);
+        REQUIRE(state.rx == 128);  // unchanged
+        REQUIRE(state.ry == y);
+    }
+}
+
+TEST_CASE("Both sticks transition through all values 0..255 simultaneously", "[parser][stateful][transition][exhaustive]") {
+    GamepadState state;
+    ResetGamepadState(state);
+
+    for (int v = 0; v <= 255; ++v) {
+        char line[64];
+        snprintf(line, sizeof(line), "0x0003 8 %02X %02X %02X %02X", v, v, v, v);
+        CAPTURE(line);
+        REQUIRE(ParseSerialLine(line, state) == true);
+        REQUIRE(state.lx == v);
+        REQUIRE(state.ly == v);
+        REQUIRE(state.rx == v);
+        REQUIRE(state.ry == v);
+    }
+}
+
+// ============================================================================
+// HAT direction tests
+// ============================================================================
+
+TEST_CASE("All HAT directions", "[parser][hat]") {
+    GamepadState state; ResetGamepadState(state);
+
+    REQUIRE(ParseSerialLine("0x0000 0", state) == true);   // TOP
+    REQUIRE(state.hat == 0);
+
+    REQUIRE(ParseSerialLine("0x0000 1", state) == true);   // TOP_RIGHT
+    REQUIRE(state.hat == 1);
+
+    REQUIRE(ParseSerialLine("0x0000 2", state) == true);   // RIGHT
+    REQUIRE(state.hat == 2);
+
+    REQUIRE(ParseSerialLine("0x0000 3", state) == true);   // BOTTOM_RIGHT
+    REQUIRE(state.hat == 3);
+
+    REQUIRE(ParseSerialLine("0x0000 4", state) == true);   // BOTTOM
+    REQUIRE(state.hat == 4);
+
+    REQUIRE(ParseSerialLine("0x0000 5", state) == true);   // BOTTOM_LEFT
+    REQUIRE(state.hat == 5);
+
+    REQUIRE(ParseSerialLine("0x0000 6", state) == true);   // LEFT
+    REQUIRE(state.hat == 6);
+
+    REQUIRE(ParseSerialLine("0x0000 7", state) == true);   // TOP_LEFT
+    REQUIRE(state.hat == 7);
+
+    REQUIRE(ParseSerialLine("0x0000 8", state) == true);   // CENTER
+    REQUIRE(state.hat == 8);
+}
+
+// ============================================================================
+// JSON test vectors
+// ============================================================================
+
+TEST_CASE("JSON test vectors can be loaded and verified", "[parser][json]") {
+    std::filesystem::path vectors_dir = std::filesystem::path(__FILE__).parent_path() / "vectors";
+    
+    if (!std::filesystem::exists(vectors_dir)) {
+        SKIP("Test vectors directory not found: " << vectors_dir);
+    }
+
+    for (const auto& entry : std::filesystem::directory_iterator(vectors_dir)) {
+        if (entry.path().extension() != ".json") continue;
+
+        std::ifstream f(entry.path());
+        REQUIRE(f.is_open());
+        
+        json j;
+        REQUIRE_NOTHROW(f >> j);
+
+        GamepadState state;
+        ResetGamepadState(state);
+
+        std::string input_line = j.value("input_line", "");
+        REQUIRE(!input_line.empty());
+
+        REQUIRE(ParseSerialLine(input_line.c_str(), state) == true);
+        
+        REQUIRE(state.buttons == j.value("expected_buttons", 0));
+        REQUIRE(state.hat == j.value("expected_hat", 8));
+        REQUIRE(state.lx == j.value("expected_lx", 128));
+        REQUIRE(state.ly == j.value("expected_ly", 128));
+        REQUIRE(state.rx == j.value("expected_rx", 128));
+        REQUIRE(state.ry == j.value("expected_ry", 128));
+    }
+}

--- a/tests/vectors/all_buttons.json
+++ b/tests/vectors/all_buttons.json
@@ -1,0 +1,10 @@
+{
+  "description": "全ボタン同時押し",
+  "input_line": "0xFFFC 8",
+  "expected_buttons": 16383,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/basic_buttons_only.json
+++ b/tests/vectors/basic_buttons_only.json
@@ -1,0 +1,10 @@
+{
+  "description": "Aボタンのみ、スティックなし",
+  "input_line": "0x0010 8",
+  "expected_buttons": 4,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/boundary_values.json
+++ b/tests/vectors/boundary_values.json
@@ -1,0 +1,10 @@
+{
+  "description": "境界値 0, 128, 255",
+  "input_line": "0x0003 8 00 80 FF 00",
+  "expected_buttons": 0,
+  "expected_hat": 8,
+  "expected_lx": 0,
+  "expected_ly": 128,
+  "expected_rx": 255,
+  "expected_ry": 0
+}

--- a/tests/vectors/button_a.json
+++ b/tests/vectors/button_a.json
@@ -1,0 +1,10 @@
+{
+  "description": "Aボタン単独",
+  "input_line": "0x0010 8",
+  "expected_buttons": 4,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_b.json
+++ b/tests/vectors/button_b.json
@@ -1,0 +1,10 @@
+{
+  "description": "Bボタン単独",
+  "input_line": "0x0008 8",
+  "expected_buttons": 2,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_capture.json
+++ b/tests/vectors/button_capture.json
@@ -1,0 +1,10 @@
+{
+  "description": "CAPTUREボタン単独",
+  "input_line": "0x8000 8",
+  "expected_buttons": 8192,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_home.json
+++ b/tests/vectors/button_home.json
@@ -1,0 +1,10 @@
+{
+  "description": "HOMEボタン単独",
+  "input_line": "0x4000 8",
+  "expected_buttons": 4096,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_l.json
+++ b/tests/vectors/button_l.json
@@ -1,0 +1,10 @@
+{
+  "description": "Lボタン単独",
+  "input_line": "0x0040 8",
+  "expected_buttons": 16,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_lclick.json
+++ b/tests/vectors/button_lclick.json
@@ -1,0 +1,10 @@
+{
+  "description": "LCLICKボタン単独",
+  "input_line": "0x1000 8",
+  "expected_buttons": 1024,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_minus.json
+++ b/tests/vectors/button_minus.json
@@ -1,0 +1,10 @@
+{
+  "description": "MINUSボタン単独",
+  "input_line": "0x0400 8",
+  "expected_buttons": 256,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_plus.json
+++ b/tests/vectors/button_plus.json
@@ -1,0 +1,10 @@
+{
+  "description": "PLUSボタン単独",
+  "input_line": "0x0800 8",
+  "expected_buttons": 512,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_r.json
+++ b/tests/vectors/button_r.json
@@ -1,0 +1,10 @@
+{
+  "description": "Rボタン単独",
+  "input_line": "0x0080 8",
+  "expected_buttons": 32,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_rclick.json
+++ b/tests/vectors/button_rclick.json
@@ -1,0 +1,10 @@
+{
+  "description": "RCLICKボタン単独",
+  "input_line": "0x2000 8",
+  "expected_buttons": 2048,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_x.json
+++ b/tests/vectors/button_x.json
@@ -1,0 +1,10 @@
+{
+  "description": "Xボタン単独",
+  "input_line": "0x0020 8",
+  "expected_buttons": 8,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_y.json
+++ b/tests/vectors/button_y.json
@@ -1,0 +1,10 @@
+{
+  "description": "Yボタン単独",
+  "input_line": "0x0004 8",
+  "expected_buttons": 1,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_zl.json
+++ b/tests/vectors/button_zl.json
@@ -1,0 +1,10 @@
+{
+  "description": "ZLボタン単独",
+  "input_line": "0x0100 8",
+  "expected_buttons": 64,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/button_zr.json
+++ b/tests/vectors/button_zr.json
@@ -1,0 +1,10 @@
+{
+  "description": "ZRボタン単独",
+  "input_line": "0x0200 8",
+  "expected_buttons": 128,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/combo_abxy.json
+++ b/tests/vectors/combo_abxy.json
@@ -1,0 +1,10 @@
+{
+  "description": "ABXY同時押し",
+  "input_line": "0x003C 8",
+  "expected_buttons": 15,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/combo_lrzlzr.json
+++ b/tests/vectors/combo_lrzlzr.json
@@ -1,0 +1,10 @@
+{
+  "description": "LRZLZR同時押し",
+  "input_line": "0x03C0 8",
+  "expected_buttons": 240,
+  "expected_hat": 8,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/combo_with_sticks.json
+++ b/tests/vectors/combo_with_sticks.json
@@ -1,0 +1,10 @@
+{
+  "description": "全ボタン+両スティック",
+  "input_line": "0xFFFF 8 00 00 FF FF",
+  "expected_buttons": 16383,
+  "expected_hat": 8,
+  "expected_lx": 0,
+  "expected_ly": 0,
+  "expected_rx": 255,
+  "expected_ry": 255
+}

--- a/tests/vectors/full_command.json
+++ b/tests/vectors/full_command.json
@@ -1,0 +1,10 @@
+{
+  "description": "A+Bボタン + 両スティック",
+  "input_line": "0x001B 8 00 00 FF FF",
+  "expected_buttons": 6,
+  "expected_hat": 8,
+  "expected_lx": 0,
+  "expected_ly": 0,
+  "expected_rx": 255,
+  "expected_ry": 255
+}

--- a/tests/vectors/left_stick.json
+++ b/tests/vectors/left_stick.json
@@ -1,0 +1,10 @@
+{
+  "description": "Aボタン + 左スティック X=255 Y=128",
+  "input_line": "0x0012 8 FF 80",
+  "expected_buttons": 4,
+  "expected_hat": 8,
+  "expected_lx": 255,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 128
+}

--- a/tests/vectors/right_stick.json
+++ b/tests/vectors/right_stick.json
@@ -1,0 +1,10 @@
+{
+  "description": "右スティックのみ X=128 Y=255",
+  "input_line": "0x0001 2 80 FF",
+  "expected_buttons": 0,
+  "expected_hat": 2,
+  "expected_lx": 128,
+  "expected_ly": 128,
+  "expected_rx": 128,
+  "expected_ry": 255
+}


### PR DESCRIPTION
## Summary

Add host-side unit tests for the serial command parser using Catch2, without requiring Pico SDK or hardware mocking.

## Changes

- **Extract parser logic** from \`PokeControllerForPico_Func.cpp\` into \`src/serial_parser.h/cpp\` (pure C++, no Pico SDK deps)
- **Add Catch2 tests** in \`tests/test_parser.cpp\` covering:
  - Button-only commands
  - Left/right/both stick parsing
  - Stick value persistence when flags are unset
  - Boundary values (0, 128, 255)
  - Multiple button OR
  - Error cases (empty string, non-numeric)
  - JSON test vector loading
- **Add JSON test vectors** in \`tests/vectors/\`
- **CMake**: add \`BUILD_TESTING\` option to build tests without Pico SDK
- **CI**: add \`Host-tests\` job to GitHub Actions (no socat / Pico SDK / Python required)
- **Refactor** \`PokeControllerForPico_Func.cpp\` to use the extracted parser

## Notes

- Fixes global variable accumulation bug in original hex parser
- Preserves original stick assignment behavior for use_right-only case
- Firmware build verified with Pico SDK 2.2.0